### PR TITLE
Remove JSON

### DIFF
--- a/varia_model.gemspec
+++ b/varia_model.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.version       = VariaModel::VERSION
   spec.required_ruby_version = ">= 1.9.1"
 
-  spec.add_dependency "json", ">= 1.7.7"
   spec.add_dependency "hashie", ">= 2.0.2"
   spec.add_dependency "buff-extensions", "~> 0.2"
 


### PR DESCRIPTION
We are Ruby 1.9 :up:. We don't need the JSON gem
