### PR TITLE
Fix json generation

### DIFF
--- a/lib/varia_model.rb
+++ b/lib/varia_model.rb
@@ -253,10 +253,14 @@ module VariaModel
   # @option options [Class, Symbol, String] :adapter
   #
   # @return [String]
-  def to_json(options = {})
-    JSON.generate(to_hash, options)
+  def to_json(*options)
+    as_json.to_json(*options)
   end
-  alias_method :as_json, :to_json
+
+  # @return [Hash]
+  def as_json(*)
+    to_hash.merge(JSON.create_id => self.class.name)
+  end
 
   # Convert the object to a hash.
   def to_hash

--- a/spec/unit/varia_model_spec.rb
+++ b/spec/unit/varia_model_spec.rb
@@ -623,20 +623,22 @@ describe VariaModel do
   end
 
   describe "#to_json" do
-    subject do
-      Class.new do
-        include VariaModel
+    class Playa
+      include VariaModel
 
-        attribute 'first_name', type: String
-        attribute 'nick', type: String
-      end.new
+      attribute 'first_name', type: String
+      attribute 'nick', type: String
+    end
+
+    subject do
+      Playa.new
     end
 
     it "returns a JSON string containin the serialized attributes" do
       subject.first_name = "brooke"
       subject.nick = "leblanc"
 
-      expect(subject.to_json).to eql(JSON.dump(first_name: "brooke", nick: "leblanc"))
+      expect(subject.to_json).to eql(JSON.dump(first_name: "brooke", nick: "leblanc", json_class: "Playa"))
     end
 
     it "includes the most recent value for any Procs" do


### PR DESCRIPTION
as_json is used by Rails and is expected to return a data structure, not a
JSON string. This is causing double-encoded errors when used in apps that
include ActiveSupport.

This change makes JSON generation match the pattern used by the JSON gem's
internal extensions.
