### PR TITLE
Skip JSON.create_id when it is nil

### DIFF
--- a/lib/varia_model.rb
+++ b/lib/varia_model.rb
@@ -259,7 +259,9 @@ module VariaModel
 
   # @return [Hash]
   def as_json(*)
-    to_hash.merge(JSON.create_id => self.class.name)
+    opts = {}
+    opts[JSON.create_id] = self.class.name if JSON.create_id
+    to_hash.merge(opts)
   end
 
   # Convert the object to a hash.

--- a/spec/unit/varia_model_spec.rb
+++ b/spec/unit/varia_model_spec.rb
@@ -647,6 +647,24 @@ describe VariaModel do
 
       expect(subject.to_json).to eql(JSON.dump(first_name: "Seth", nick: "NAME", json_class: "Playa"))
     end
+
+    describe "when JSON.create_id is nil" do
+      before do
+        @_old_create_id = JSON.create_id
+        JSON.create_id = nil
+      end
+
+      after do
+        JSON.create_id = @_old_create_id
+      end
+
+      it "does not include a nil key" do
+        subject.first_name = "brooke"
+        subject.nick = "leblanc"
+
+        expect(subject.to_json).to eql(JSON.dump(first_name: "brooke", nick: "leblanc"))
+      end
+    end
   end
 
   describe "#to_hash" do


### PR DESCRIPTION
Addresses fails in RiotGames/ridley#236 and will need to be included there.
