### PR TITLE
Lock down Hashie version.

### DIFF
--- a/varia_model.gemspec
+++ b/varia_model.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.version       = VariaModel::VERSION
   spec.required_ruby_version = ">= 1.9.1"
 
-  spec.add_dependency "hashie", ">= 2.0.2"
+  spec.add_dependency "hashie", ">= 2.0.2", "< 3.0.0"
   spec.add_dependency "buff-extensions", "~> 1.0"
 
   spec.add_development_dependency "buff-ruby_engine", "~> 0.1"


### PR DESCRIPTION
The new version of Hashie (3.0) changes dependencies, and is currently in development. We should ensure we're using a version before 3.0 until the issues are resolved in a better way.
