### PR TITLE
Compatible with hashie 3

### DIFF
--- a/lib/varia_model/attributes.rb
+++ b/lib/varia_model/attributes.rb
@@ -1,5 +1,4 @@
 require 'hashie'
-require 'hashie/hash_extensions'
 require 'hashie/mash'
 
 module VariaModel

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,6 @@ def setup_rspec
     end
 
     config.mock_with :rspec
-    config.treat_symbols_as_metadata_keys_with_true_values = true
     config.filter_run focus: true
     config.run_all_when_everything_filtered = true
   end

--- a/spec/support/matchers/each.rb
+++ b/spec/support/matchers/each.rb
@@ -6,7 +6,7 @@ RSpec::Matchers.define :each do |check|
     end
   end
 
-  failure_message_for_should do |actual|
-    "at[#{@object}] #{check.failure_message_for_should}"
+  failure_message do |actual|
+    "at[#{@object}] #{check.failure_message}"
   end
 end

--- a/spec/unit/varia_model_spec.rb
+++ b/spec/unit/varia_model_spec.rb
@@ -23,19 +23,19 @@ describe VariaModel do
         subject.attribute 'jamie.winsor'
         subject.attribute 'brooke.winsor'
 
-        expect(subject.attributes).to have(2).items
+        expect(subject.attributes.size).to eq(2)
       end
 
       it "adds a validation if :required option is true" do
         subject.attribute 'brooke.winsor', required: true
 
-        expect(subject.validations).to have(1).item
+        expect(subject.validations.size).to eq(1)
       end
 
       it "adds a validation if the :type option is provided" do
         subject.attribute 'brooke.winsor', type: :string
 
-        expect(subject.validations).to have(1).item
+        expect(subject.validations.size).to eq(1)
       end
 
       it "sets a default value if :default option is provided" do
@@ -399,13 +399,13 @@ describe VariaModel do
       it "adds an error for each attribute that fails validations" do
         subject.validate
 
-        expect(subject.errors).to have(1).item
+        expect(subject.errors.size).to eq(1)
       end
 
       it "adds a message for each failed validation" do
         subject.validate
 
-        expect(subject.errors['brooke.winsor']).to have(1).item
+        expect(subject.errors['brooke.winsor'].size).to eq(1)
         expect(subject.errors['brooke.winsor'][0]).to eql("A value is required for attribute: 'brooke.winsor'")
       end
     end
@@ -428,8 +428,8 @@ describe VariaModel do
       it "adds an error if it fails validation" do
         subject.validate
 
-        expect(subject.errors).to have(1).item
-        expect(subject.errors['brooke.winsor']).to have(1).item
+        expect(subject.errors.size).to eq(1)
+        expect(subject.errors['brooke.winsor'].size).to eq(1)
         expect(subject.errors['brooke.winsor'][0]).to eql("Expected attribute: 'brooke.winsor' to be a type of: 'String', 'NilClass'")
       end
     end

--- a/varia_model.gemspec
+++ b/varia_model.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "thor", "~> 0.18.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "< 3.0.0"
   spec.add_development_dependency "fuubar"
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-rspec"

--- a/varia_model.gemspec
+++ b/varia_model.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "thor", "~> 0.18.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "< 3.0.0"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "fuubar"
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-rspec"


### PR DESCRIPTION
While trying to use berkshelf, varia_model was blowing up, due to a major version upgrade in Hashie.

Upon inspection, it seems like the file which was being required isn't even necessary.

Rather than forever constrain Hashie to an old version, let's keep up!

I also updated the specs to remove RSpec deprecation warnings when using RSpec2. These turn to failures in RSpec3.
