### PR TITLE
Allow Hashie 3.x

### DIFF
--- a/varia_model.gemspec
+++ b/varia_model.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.version       = VariaModel::VERSION
   spec.required_ruby_version = ">= 1.9.1"
 
-  spec.add_dependency "hashie", ">= 2.0.2", "< 3.0.0"
+  spec.add_dependency "hashie", ">= 2.0.2", "< 4.0.0"
   spec.add_dependency "buff-extensions", "~> 1.0"
 
   spec.add_development_dependency "buff-ruby_engine", "~> 0.1"


### PR DESCRIPTION
I found https://github.com/reset/varia_model/commit/a5e0d677d3e81810844ff95d5164422d6b7b5cf4 but it seems that newer versions of hashie 3.x are well behaved and only have development dependencies. Tests are passing for me locally.
